### PR TITLE
:zap: - Changing some underlying implementations

### DIFF
--- a/__tests__/Lenses_lists.re
+++ b/__tests__/Lenses_lists.re
@@ -110,6 +110,19 @@ describe("Lens List atOrExn", () => {
 
 describe("Lens List find", () => {
   test(
+    "Work on big lists",
+    Lens.set(
+      Lens.List.find(9999999),
+      Some(0),
+      Belt.List.makeBy(10000000, Lib.Function.id),
+    )
+    ->Belt.List.get(9999999)
+    |> expect
+    |> toEqual(Some(0))
+    |> Lib.Function.const,
+  );
+
+  test(
     "Expect correct update when found",
     Lens.set(metricSpeedLens >>- Lens.List.find(5), Some(200), metric)
     |> expect

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-pancake",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "scripts": {
     "start": "bsb -clean-world -make-world -w",
     "build-lib": "bsb -clean-world -make-world",

--- a/src/Lib.re
+++ b/src/Lib.re
@@ -28,31 +28,17 @@ module Array = {
 };
 
 module List = {
-  let updateAtIndex = (xs, i, x) => {
-    /* Instead of mapping like we do with the array,
-       we splice the linked list and re-connect them with the element
-       in the middle.
-       If 'i' < 0 -- we wrap around. Not that we do this with:
+  let updateAtIndex = (xs, i, e) => {
+    /* If 'i' < 0 -- we wrap around. Note that we do this with:
        (listLength + i) as i is a negative number (listLength - (-1))
-       and we would be out of bounds otherwise
+       and we would be out of bounds otherwise.
        */
-    let (h, t) =
-      i > 0
-        ? (Belt.List.take(xs, i), Belt.List.drop(xs, i + 1))
-        : {
-          let listLength = Belt.List.length(xs);
-          (
-            Belt.List.take(xs, listLength + i),
-            Belt.List.drop(xs, listLength + i + 1),
-          );
-        };
-
-    switch (h, t) {
-    | (Some(h), Some(t)) => Belt.List.concatMany([|h, [x], t|])
-    | (None, Some(t)) => Belt.List.concatMany([|[x], t|])
-    | (Some(h), None) => Belt.List.concatMany([|h, [x]|])
-    | (None, None) => xs
-    };
+    i > 0
+      ? Belt.List.mapWithIndex(xs, (j, x) => i === j ? e : x)
+      : {
+        let actualI = Belt.List.length(xs) + i;
+        Belt.List.mapWithIndex(xs, (j, x) => actualI === j ? e : x);
+      };
   };
 
   let rec findBy = fn =>
@@ -61,11 +47,7 @@ module List = {
     | [x, ..._] when fn(x) => Some(x)
     | [_, ...xs] => findBy(fn, xs);
 
-  let rec replaceBy = (e, fn) =>
-    fun
-    | [] => []
-    | [x, ...xs] when fn(x) => [e, ...xs]
-    | [x, ...xs] => [x, ...replaceBy(e, fn, xs)];
+  let replaceBy = (e, fn, xs) => Belt.List.map(xs, x => fn(x) ? e : x);
 };
 
 module Option = {


### PR DESCRIPTION
As it turns out this got compiled to a `while` loop in Bucklescript,
```
  let rec findBy = fn =>
    fun
    | [] => None
    | [x, ..._] when fn(x) => Some(x)
    | [_, ...xs] => findBy(fn, xs);
```

But this didn't.
```
  let rec replaceBy = (e, fn) =>
    fun
    | [] => []
    | [x, ...xs] when fn(x) => [e, ...xs]
    | [x, ...xs] => [x, ...replaceBy(e, fn, xs)];
```

In the Array version we simply map as slicing the array is O(n) anyway. For the linked list, I figured we could be more clever and simple join the rest of the list back onto itself when we've found the element. There were some attempts at cleverness, using an accumulator, but those ended up just being slower, as the accumulator would have to append to keep the order of the list, which is slow. Prepending and then reversing the list is another O(n) operation, meaning in the worst case scenario we would run 0(n*2). 
So, I ended up just mapping.
